### PR TITLE
Link to instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 Research day should be thought of as a [spike](http://www.extremeprogramming.org/rules/spike.html) to help with your end-of-week project
 
 ## Week 1 - toolkit
+[Instructions](https://github.com/foundersandcoders/master-reference/blob/f50407398f38d3093539fa0c11f605b0b5d5e869/coursebook/week-1/research-afternoon.md)
+
 + [Command Line](./week-1/customizing-command-line.md)
 
 + [Git & GitHub](https://github.com/alexis-l8/git-and-github-research)
@@ -14,6 +16,7 @@ Research day should be thought of as a [spike](http://www.extremeprogramming.org
 [Before](https://github.com/majakudlicka/majakudlicka.github.io/tree/5b0303328e47295a4b7908b15024eb764368a768) | [After](https://github.com/majakudlicka/majakudlicka.github.io)
 
 ## Week 2 - testing
+[Instructions](https://github.com/foundersandcoders/master-reference/blob/a36375530643c6b062b7167b723627db0a6a90ec/coursebook/week-2/research-afternoon.md)
 
 + [Unit vs Integration testing](nice-link-here)
 
@@ -26,7 +29,7 @@ Research day should be thought of as a [spike](http://www.extremeprogramming.org
 ## Week 3 - APIs
 
 ## Week 4 - Node 1
-
+[Instructions](https://github.com/foundersandcoders/master-reference/blob/f67d3eccea46ddbbfff49e194a110cbcb14ca7ce/coursebook/week-4/research-afternoon.md)
 
 + [Architecture](https://github.com/FAC10/research/tree/65566b076fa11c4f9228712b4f505c0b97711655)
 
@@ -36,6 +39,7 @@ Research day should be thought of as a [spike](http://www.extremeprogramming.org
 
 
 ## Week 5 - Node 2
+[Instructions](https://github.com/foundersandcoders/master-reference/blob/ed7465fd2c2f105e1bad76149947ee35bb96745f/coursebook/week-5/research-afternoon.md)
 
 + [Buffers and Streams](https://github.com/FAC10/buffers-and-streams)
 
@@ -45,6 +49,7 @@ Research day should be thought of as a [spike](http://www.extremeprogramming.org
 
 
 ## Week 6 - Postgres
+[Instructions](https://github.com/foundersandcoders/master-reference/blob/2afb8a6506987cb65cd2aa57250922f97e416426/coursebook/week-6/research-afternoon.md)
 
 + [Database setup and maintenance](./week-6/database-setup-maintenance/database-setup-maintenance.md)
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ Research day should be thought of as a [spike](http://www.extremeprogramming.org
 
 + [BlanketJS](https://github.com/FAC10/research/blob/master/week-2/blanketjs.md)
 
-## Week 3 - APIs
-
 ## Week 4 - Node 1
 [Instructions](https://github.com/foundersandcoders/master-reference/blob/f67d3eccea46ddbbfff49e194a110cbcb14ca7ce/coursebook/week-4/research-afternoon.md)
 
@@ -37,7 +35,6 @@ Research day should be thought of as a [spike](http://www.extremeprogramming.org
 
 + [Engineering](./week-4/engineering/engineering.md)
 
-
 ## Week 5 - Node 2
 [Instructions](https://github.com/foundersandcoders/master-reference/blob/ed7465fd2c2f105e1bad76149947ee35bb96745f/coursebook/week-5/research-afternoon.md)
 
@@ -46,7 +43,6 @@ Research day should be thought of as a [spike](http://www.extremeprogramming.org
 + [Continuous Integration & Travis](https://github.com/FAC10/TravisPractice)
 
 + [Make an external request from the server](https://github.com/FAC10/node-server-api-request)
-
 
 ## Week 6 - Postgres
 [Instructions](https://github.com/foundersandcoders/master-reference/blob/2afb8a6506987cb65cd2aa57250922f97e416426/coursebook/week-6/research-afternoon.md)


### PR DESCRIPTION
+ add links to the research topics page in `master-reference`, at this particular point in history (as these instructions may change for future cohorts)
+ remove unnecessary "week 3"

Fixes #33 